### PR TITLE
Remove lock mechanism

### DIFF
--- a/README
+++ b/README
@@ -25,11 +25,6 @@ and main project to use.
 The --verbose option is useful in order to watch what obs-autosubmit is
 deciding,
 
-To protect against running this tool twice at the same time (which would be
-expensive in terms of interaction with the OBS server), obs-autosubmit has some
-(very basic) lock mechanism. In case obs-autosubmit is locked with no reason,
-just remove the file "running" from the cache directory.
-
 
 Disabling autosubmit behavior for a project or a package
 ========================================================

--- a/obs-autosubmit
+++ b/obs-autosubmit
@@ -1217,28 +1217,6 @@ class AutoSubmitWorker:
 #######################################################################
 
 
-def lock_run(conf):
-    # FIXME: this is racy, we need a real lock file. Or use an atomic operation
-    # like mkdir instead
-    running_file = os.path.join(conf.cache_dir, 'running')
-
-    if os.path.exists(running_file):
-        return False
-
-    open(running_file, 'w').write('')
-
-    return True
-
-
-def unlock_run(conf):
-    running_file = os.path.join(conf.cache_dir, 'running')
-
-    os.unlink(running_file)
-
-
-#######################################################################
-
-
 def main(args):
     parser = optparse.OptionParser()
 
@@ -1290,10 +1268,6 @@ def main(args):
             return 1
 
     try:
-        if not lock_run(conf):
-            print('Another instance of the script is running.', file=sys.stderr)
-            return 1
-
         worker = AutoSubmitWorker(conf)
 
         retval = 1
@@ -1314,8 +1288,6 @@ def main(args):
         # Handle this nicely as we want to remove the lock
         print('Interrupted...')
         retval = 0
-
-    unlock_run(conf)
 
     return retval
 


### PR DESCRIPTION
As obs-autosubmit is run in the gocd instance, we have a guarantee already
that the bot is never run in parallel. No need to extra safeguards.