### PR TITLE
Improve check for request revision equality

### DIFF
--- a/obs-autosubmit
+++ b/obs-autosubmit
@@ -1058,7 +1058,7 @@ class AutoSubmitWorker:
             parent_package.fetch_latest_package_state(self.conf.apiurl, nodetails = True)
             # See hash documentation in AutoSubmitPackage for why we use
             # state_hash and not unexpanded_state_hash
-            if parent_package.state_hash ==  devel_package.state_hash:
+            if parent_package.state_hash == devel_package.state_hash:
                 _verbose_print_not_submitting(self, devel_package, parent_package, FILTER_REASON_OUT_OF_DATE_STATUS, None)
                 return (True, FILTER_REASON_OUT_OF_DATE_STATUS, None)
 

--- a/obs-autosubmit
+++ b/obs-autosubmit
@@ -895,7 +895,7 @@ class AutoSubmitWorker:
                 # Can't handle that, really
                 return False
             if type(value) != str:
-                print('Unexpected attribute type: %s' (type(value),), file=sys.stderr)
+                print('Unexpected attribute type: %s' % (type(value),), file=sys.stderr)
                 return False
             return value.lower() in [ 'true', 'on', '1' ]
 

--- a/obs-autosubmit
+++ b/obs-autosubmit
@@ -391,6 +391,8 @@ class AutoSubmitPackage:
         self.state_hash = state_hash
         self.unexpanded_state_hash = unexpanded_state_hash
         self.rev = rev
+        # All revs which refer to the current package's state
+        self.revs = set()
         self.changes_hash = changes_hash
         self.max_mtime = max_mtime
         self.attributes = None
@@ -422,6 +424,9 @@ class AutoSubmitPackage:
 
         # Update changes_hash
         directory_node = fetch_package_files_metadata(apiurl, self.project, self.package, expand = True)
+
+        # Numeric revision, expanded srcmd5 and unexpanded srcmd5
+        self.revs = set([rev, sourceinfo_node.get('srcmd5'), sourceinfo_node.get('lsrcmd5')])
 
         self.changes_md5 = None
 
@@ -873,7 +878,7 @@ class AutoSubmitWorker:
                     print('Ignoring request %s: source mis-defined.' % request_id, file=sys.stderr)
                     continue
 
-                if devel_package == source and devel_package.rev == source.rev:
+                if devel_package == source and source.rev in devel_package.revs:
                     return request_id
 
         return None
@@ -1029,7 +1034,7 @@ class AutoSubmitWorker:
                 if devel_package != source:
                     continue
 
-                if source.rev == devel_package.rev:
+                if source.rev in devel_package.revs:
                     old_sr = request_id
                     break
 


### PR DESCRIPTION
A package revision can be in multiple formats:
a) the numeric revision
b) srcmd5 (hash of the unexpanded package contents)
c) xsrcmd5 (hash of the expanded package contents)

A request can contain any of those as source revision.

To check whether a particular package was already submitted, look at all of
those.

I tested this by looking at the `tor` submission. Before:

```
Not submitting network/tor to openSUSE:Factory/tor: changes already seen in the past [already submitted (918873)].
Filtered network/tor -> openSUSE:Factory/tor
```

Now:

```
Not submitting network/tor to openSUSE:Factory/tor: already submitted (918873).
Filtered network/tor -> openSUSE:Factory/tor
```

Fixes #1.